### PR TITLE
fix grc gui closing under windows

### DIFF
--- a/release/resources/py_launcher.bat.in
+++ b/release/resources/py_launcher.bat.in
@@ -2,5 +2,5 @@
 
 pushd "%~dp0"
 set PATH=%CD%;%CD%\..\Python@PYTHON_SHORT_VER@\Lib\site-packages\gi\gtk\bin;%PATH%
-@GEN_PY_PYTHON@ -i @mod@.py
+@GEN_PY_PYTHON@ @mod@.py
 popd


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->
## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
installer: removed the interactive mode for python launchers

Since -i forces the python prompt, the application does not fully close.
This lead to an open, non-closeable GRC GUI when running the GUI based
application. The user always need to stop the python shell manually to
get the GUI closed. By removing interactive mode here, the python shell
closes automatically and with this the GUI.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
installer / py_launchers under windows

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

Manual testing under Windows 11.

With `-i` the GUI remains open:
<img width="1814" height="634" alt="image" src="https://github.com/user-attachments/assets/a9b109ac-4264-4909-999e-c38dd8857383" />

without `-i` the closes automatically:
<img width="678" height="626" alt="image" src="https://github.com/user-attachments/assets/1ca9c38c-dbc3-4b3f-828b-26c76784b2d9" />


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [ ] I have squashed my commits to have one significant change per commit. 
- [ ] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
